### PR TITLE
Adding Prometheus metrics scrape annotations

### DIFF
--- a/examples/daemonset/nginx/nginx-ingress-daemonset.yaml
+++ b/examples/daemonset/nginx/nginx-ingress-daemonset.yaml
@@ -10,6 +10,9 @@ spec:
     metadata:
       labels:
         name: nginx-ingress-lb
+      annotations:
+        prometheus.io/port: '10254'
+        prometheus.io/scrape: 'true'
     spec:
       terminationGracePeriodSeconds: 60
       containers:

--- a/examples/deployment/nginx/nginx-ingress-controller.yaml
+++ b/examples/deployment/nginx/nginx-ingress-controller.yaml
@@ -11,6 +11,9 @@ spec:
     metadata:
       labels:
         k8s-app: nginx-ingress-controller
+      annotations:
+        prometheus.io/port: '10254'
+        prometheus.io/scrape: 'true'
     spec:
       # hostNetwork makes it possible to use ipv6 and to preserve the source IP correctly regardless of docker configuration
       # however, it is not a hard dependency of the nginx-ingress-controller itself and it may cause issues if port 10254 already is taken on the host


### PR DESCRIPTION
Allow Prometheus automatic discovery of nginx metrics endpoint

Fixed https://github.com/kubernetes/ingress/issues/464